### PR TITLE
Exclude  in apache log

### DIFF
--- a/roles/apache24/templates/virtualhost.conf.j2
+++ b/roles/apache24/templates/virtualhost.conf.j2
@@ -1,6 +1,7 @@
 <VirtualHost *:80>
     ServerName {{ item.domain }}
     DocumentRoot /var/www/{{ item.domain }}/
-    CustomLog logs/{{ item.domain }}-access_log combined-elb
+    SetEnvIf User-Agent "ELB-HealthChecker.*" nolog
+    CustomLog logs/{{ item.domain }}-access_log combined-elb env=!nolog
     ErrorLog logs/{{ item.domain }}-error_log
 </VirtualHost>


### PR DESCRIPTION
以下のようなELB-HealthCheckerのログをapacheのアクセスログから除外します。
```
- - - [29/Jun/2017:17:33:06 +0900] "GET / HTTP/1.1" 200 11230 "-" "ELB-HealthChecker/1.0"
- - - [29/Jun/2017:17:33:13 +0900] "GET / HTTP/1.1" 200 11230 "-" "ELB-HealthChecker/1.0"
- - - [29/Jun/2017:17:33:21 +0900] "GET / HTTP/1.1" 200 11230 "-" "ELB-HealthChecker/1.0"
```